### PR TITLE
build: update TypeScript config for monorepo path resolution

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,13 +8,14 @@ import { Router } from '../components';
 // import { useConfig } from '@dhis2/app-runtime';
 import { D2I18n } from 'dhis2-semis-types';
 
-export default function SchoolCalendar({ i18n }: { i18n: D2I18n }) {
-    // const { baseUrl } = useConfig()
+export default function SchoolCalendar({ i18n, baseUrl }: { i18n: D2I18n; baseUrl?: string }) {
+    // const { baseUrl: localBaseUrl } = useConfig()
+    // const useBaseUrl = baseUrl || localBaseUrl
 
     return (
         // <AppWrapper
         //     schoolCalendarKey='dataStore/semis/schoolCalendar'
-        //     baseUrl={baseUrl}
+        //     baseUrl={useBaseUrl}
         //     dataStoreKey="dataStore/semis/values"
         // >
         //     <HashRouter>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,12 @@
       "declarationDir": "./dist/declarations",
       "jsx": "preserve",
       "outDir": "./dist",
-      "rootDir": "./src",
+      "rootDir": "../..",
+      "paths": {
+        "dhis2-semis-components": ["../../libs/components/src"],
+        "dhis2-semis-functions": ["../../libs/functions/src"],
+        "dhis2-semis-types": ["../../libs/types/src"]
+      }
   },
   "exclude": [
       "node_modules",


### PR DESCRIPTION
Add path mappings for internal libraries (components, functions, types) to enable proper module resolution within the monorepo structure. This allows TypeScript to correctly resolve imports from these packages during development and compilation.